### PR TITLE
增加了船的四个模式和一些参数

### DIFF
--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -32,6 +32,10 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(QObject *parent)
         { APMRoverMode::RTL          , _rtlFlightMode          },
         { APMRoverMode::SMART_RTL    , _smartRtlFlightMode     },
         { APMRoverMode::GUIDED       , _guidedFlightMode       },
+        { APMRoverMode::PROPELLER      , QStringLiteral("Propeller")     },
+        { APMRoverMode::OMNI_MANUAL    , QStringLiteral("O-Manual")      },
+        { APMRoverMode::OMNI_HEADING   , QStringLiteral("O-Heading")     },
+        { APMRoverMode::OMNI_POSITION  , QStringLiteral("O-Position")    },
         { APMRoverMode::INITIALIZING , _initializingFlightMode },
     });
 
@@ -51,6 +55,10 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(QObject *parent)
         { _rtlFlightMode          , APMRoverMode::RTL          , true , true},
         { _smartRtlFlightMode     , APMRoverMode::SMART_RTL    , true , true},
         { _guidedFlightMode       , APMRoverMode::GUIDED       , true , true},
+        { QStringLiteral("Propeller")     , APMRoverMode::PROPELLER     , true , true},
+        { QStringLiteral("O-Manual")      , APMRoverMode::OMNI_MANUAL   , true , true},
+        { QStringLiteral("O-Heading")     , APMRoverMode::OMNI_HEADING  , true , true},
+        { QStringLiteral("O-Position")    , APMRoverMode::OMNI_POSITION , true , true},
         { _initializingFlightMode , APMRoverMode::INITIALIZING , true , true},
     };
     updateAvailableFlightModes(availableFlightModes);

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -28,7 +28,11 @@ struct APMRoverMode
         RTL             = 11,
         SMART_RTL       = 12,
         GUIDED          = 15,
-        INITIALIZING    = 16
+        INITIALIZING    = 16,
+        PROPELLER       = 20,//in QGC settings, FRAME_TYPE_OMNIBP = 4
+        OMNI_MANUAL     = 21,
+        OMNI_HEADING    = 22,
+        OMNI_POSITION   = 23,
     };
 };
 


### PR DESCRIPTION
增加了船的四个模式和一些参数

对应老版本的链接：https://git.ehfly.com:55001/yacht/qgroundcontrol/-/commit/94d67c181dce1cdad9c9697d2dc12a5542f56711

新版的QGC与老版本会有不同，不过新版本不需要对xml文件进行修改（新版本就没有xml文件...），由C++取代了其它形式的报文

请注意如果需要使用这些新加的模式，需要手动设置frame_type的数值（例如需要使用O-Manual，就需要设置frame_type=FRAME_TYPE_OMNIBP (FRAME_TYPE_OMNIBP = 4)

