### PR TITLE
增加YACHT_HUD报文，并于QGC代码中会自动拉取目标报文

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -38,8 +38,8 @@ option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Backend" OFF) # Q
 set(SDL_GAMECONTROLLERCONFIG "0300000009120000544f000011010000,OpenTX Radiomaster TX16S Joystick,leftx:a3,lefty:a2,rightx:a0,righty:a1,platform:Linux" CACHE STRING "Custom SDL Joystick Mappings")
 
 # MAVLink
-set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")
-set(QGC_MAVLINK_GIT_TAG "19f9955598af9a9181064619bd2e3c04bd2d848a" CACHE STRING "Tag of MAVLink Git Repo")
+set(QGC_MAVLINK_GIT_REPO "https://github.com/new-tonAA/c_library_v2.git") # my own repository
+set(QGC_MAVLINK_GIT_TAG "master")  # 或你想要用的分支/commit
 
 # APM
 option(QGC_DISABLE_APM_MAVLINK "Disable APM Dialect" OFF)

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -66,6 +66,7 @@
         <file alias="Viewer3D.SettingsGroup.json">src/Settings/Viewer3D.SettingsGroup.json</file>
         <file alias="GimbalController.SettingsGroup.json">src/Settings/GimbalController.SettingsGroup.json</file>
         <file alias="CameraMetaData.json">src/Camera/CameraMetaData.json</file>
+        <file>src/Vehicle/FactGroups/YachtHudFact.json</file>
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduSubMockLink.params">src/Comms/MockLink/APMArduSubMockLink.params</file>


### PR DESCRIPTION
## 1. 增加了YACHT_HUD报文
- 在QGC目标代码中会自动拉取想要的仓库：https://github.com/new-tonAA/c_library_v2
- 这也就意味着，所有报文文件都不会由QGC源码本地去管理

现在的仓库结构：
- https://github.com/new-tonAA/qgroundcontrol QGC源码
- https://github.com/new-tonAA/mavlink 报文xml文件，如果添加报文，需要首先在这里添加，然后再用python生成下面的仓库
- https://github.com/new-tonAA/c_library_v2 报文通过python生成的头文件，是QGC源码编译时获取的对象

## 2.  将一个json文件注册于qrc文件中