### PR TITLE
fix the PX4ParameterfactMetaData.xml's int bug

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -26403,7 +26403,7 @@
       <short_desc>Module IDs [0, 31] that you would like to request telemetry from</short_desc>
       <long_desc>The module IDs [0, 31] that should be asked for telemetry. The data received from these IDs will be published via the esc_status topic.</long_desc>
       <min>0</min>
-      <max>4294967295</max>
+      <max>2147483647</max>
       <reboot_required>True</reboot_required>
       <bitmask>
         <bit index="0">Module ID 0</bit>


### PR DESCRIPTION
之前的int范围有误导致linux的debug CI难通过，现在修复了这个问题