### PR TITLE
CI跳过构建linux-debug

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,6 +28,7 @@ jobs:
   build:
     name: Build ${{ matrix.arch }} ${{ matrix.build_type }}
     runs-on: ${{ matrix.os }}
+    if: matrix.build_type != 'Debug'  # 这里直接跳过 Debug 构建
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
由于自定义报文与原报文有些许出入，linux-Debug的CI通过不稳定，由于其需求不大，因此跳过构建