### PR TITLE
stable版本，此PR是为了获得产物

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ cpm_modules
 
 #ardupilot parameter
 src/FirmwarePlugin/APM/Ardupilot-Parameter-Repository
+src/FirmwarePlugin/APM/ArduPilot-Parameter-Repository/

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -327,7 +327,6 @@ bool APMFirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle *vehicle, mavlink_m
     if (instanceData && ((instanceData->lastBatteryStatusTime.secsTo(QTime::currentTime()) > reinitStreamsTimeoutSecs) || (instanceData->lastHomePositionTime.secsTo(QTime::currentTime()) > reinitStreamsTimeoutSecs))) {
         initializeStreamRates(vehicle);
     }
-
     return true;
 }
 


### PR DESCRIPTION
已经在另外一个仓库修复了mavlink报文，现在Yacht_Hud报文是正常运作的。

**相关仓库的联系：**

> 报文原文：
> https://github.com/new-tonAA/mavlink
> 原文用python生成的给QGC使用的头文件：
> https://github.com/new-tonAA/c_library_v2
> vehicle类型的文件仓库：
> https://github.com/new-tonAA/ParameterRepository